### PR TITLE
Add incrementVersion() with semver

### DIFF
--- a/lib/Tiapp.js
+++ b/lib/Tiapp.js
@@ -201,6 +201,42 @@ Tiapp.prototype.removePlugin = function removePlugin(id) {
 	removeItem(this.doc.documentElement, 'plugin', id);
 };
 
+Tiapp.prototype.incrementVersion = function incrementVersion(release) {
+	var semver = require('semver'),
+		current = this.version || '1.0.0',
+		androids, manifests, manifest;
+
+	// if release (type) not specified, assume patch
+	if (!release || typeof release !== 'string' || ['major', 'minor', 'patch'].indexOf(release) === -1) {
+		release = 'patch';
+	}
+	// increment & set version for iOS (I assume also MobileWeb & Blackberry)
+	if(current.split('.').length === 2) {
+		current += '.0';
+	}
+	this.version = (semver.valid(current)) ? semver.inc(current, release) : '1.0.0';
+
+	// set Android versions
+	androids = this.doc.documentElement.getElementsByTagName('android');
+	if (androids.length === 1) {
+		manifests = androids.item(0).getElementsByTagName('manifest');
+		if (manifests.length === 1) {
+			manifest = manifests.item(0);
+
+			// set versionName - what the user sees
+			if (manifest.hasAttribute('android:versionName')) {
+				manifest.setAttribute('android:versionName', this.version);
+			}
+			// increment the versionCode
+			if (manifest.hasAttribute('android:versionCode')) {
+				manifest.setAttribute('android:versionCode', (parseInt(manifest.getAttribute('android:versionCode'), 10)+1));
+			}
+		}
+	}
+
+	return this.version;
+};
+
 module.exports = Tiapp;
 
 // helpers

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "grunt-contrib-jshint": "~0.10.0",
     "should": "~3.3.0",
     "lodash": "~2.4.1",
-    "grunt-contrib-clean": "~0.5.0"
+    "grunt-contrib-clean": "~0.5.0",
+    "semver": "~4.1.0"
   },
   "engines": {
     "node": ">=0.10"

--- a/test/fixtures/tiapp.xml
+++ b/test/fixtures/tiapp.xml
@@ -38,7 +38,9 @@
 		</plist>
 	</ios>
 	<android xmlns:android="http://schemas.android.com/apk/res/android">
-	</android>
+<!-- 		<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.appcelerator.props" android:versionCode="1" android:versionName="1.0"/>
+ -->
+ 	</android>
 	<mobileweb>
 		<precache>
 		</precache>

--- a/test/tiapp_test.js
+++ b/test/tiapp_test.js
@@ -298,7 +298,27 @@ describe('Tiapp', function() {
 			should.equal(tiapp.getProperty('ti.ui.defaultunit'), null);
 		});
 
-		it('should get all modules', function() {
+		it('should increment the version', function() {
+			var tiapp = tiappXml.load(TIAPP_XML);
+
+			tiapp.incrementVersion('major');
+			tiapp.version.should.equal('2.0.0');
+
+			tiapp.incrementVersion('minor');
+			tiapp.version.should.equal('2.1.0');
+
+			tiapp.incrementVersion('patch');
+			tiapp.version.should.equal('2.1.1');
+
+			var manifest = tiapp.doc.documentElement.getElementsByTagName('android').item(0).getElementsByTagName('manifest').item(0);
+
+			if(manifest) {
+				manifest.getAttribute('android:versionName').should.equal('2.1.1');
+				manifest.getAttribute('android:versionCode').should.equal('4');
+			}
+
+		});
+			it('should get all modules', function() {
 			var tiapp = tiappXml.load(TIAPP_XML);
 
 			var modules = tiapp.getModules();


### PR DESCRIPTION
Implements Fokke's incrementVersion() function using semver. I changed this also to increment & save the android:versionName value, as that is the value seen by the user. To see this work with the android version attributes, uncomment the manifest tag in tiapp.xml. I left that commented out to show that the tests work with or without that tag.
